### PR TITLE
Wrap URLs across multiple lines

### DIFF
--- a/bioRxiv.cls
+++ b/bioRxiv.cls
@@ -94,6 +94,7 @@
   \linenumbers
 \fi
 
+\PassOptionsToPackage{hyphens}{url}
 %% Hyperlinking
 \RequirePackage[colorlinks=true, allcolors=blue]{hyperref}
 \RequirePackage{orcidlink}


### PR DESCRIPTION
Thanks for this amazing template.

This change would prevent URLs from ever overflowing outside the bounding box of the page (https://tex.stackexchange.com/a/3034), which can be an issue particularly in the bibliography. No pressure to merge.